### PR TITLE
fix(platform): use segments[0] of activePeriod instead of activeSegment for initialize

### DIFF
--- a/packages/platform/src/services/GameService.ts
+++ b/packages/platform/src/services/GameService.ts
@@ -1338,7 +1338,7 @@ export function computeSegmentStartResults(game, ctx, { services }) {
   // Use first segment of active period and not activeSegment as it's not
   // active yet.
   const activePeriod = game.activePeriod
-  const activeSegment = activePeriod.segments[0]
+  const aboutToBeactiveSegment = activePeriod.segments[0]
 
   // if it is the first segment, transform PERIOD_START to SEGMENT_START
   const results = game.activePeriod.results
@@ -1349,8 +1349,8 @@ export function computeSegmentStartResults(game, ctx, { services }) {
         {
           playerRole: result.player.role,
           periodFacts: game.activePeriod.facts,
-          segmentFacts: activeSegment.facts,
-          nextSegmentFacts: activeSegment.nextSegment?.facts,
+          segmentFacts: aboutToBeactiveSegment.facts,
+          nextSegmentFacts: aboutToBeactiveSegment.nextSegment?.facts,
           segmentIx: nextSegmentIx,
         }
       )

--- a/packages/platform/src/services/GameService.ts
+++ b/packages/platform/src/services/GameService.ts
@@ -1335,6 +1335,11 @@ export function computeSegmentStartResults(game, ctx, { services }) {
     }
   }
 
+  // Use first segment of active period and not activeSegment as it's not
+  // active yet.
+  const activePeriod = game.activePeriod
+  const activeSegment = activePeriod.segments[0]
+
   // if it is the first segment, transform PERIOD_START to SEGMENT_START
   const results = game.activePeriod.results
     .filter((result) => result.type === DB.PlayerResultType.PERIOD_START)
@@ -1344,8 +1349,8 @@ export function computeSegmentStartResults(game, ctx, { services }) {
         {
           playerRole: result.player.role,
           periodFacts: game.activePeriod.facts,
-          segmentFacts: game.activePeriod.activeSegment?.facts,
-          nextSegmentFacts: game.activePeriod.activeSegment?.nextSegment?.facts,
+          segmentFacts: activeSegment.facts,
+          nextSegmentFacts: activeSegment.nextSegment?.facts,
           segmentIx: nextSegmentIx,
         }
       )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of segment results by updating the way segment data is selected, ensuring that the correct segment is used for calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->