### PR TITLE
fix(platform): update game facts during prep/pause except very first one

### DIFF
--- a/apps/demo-game/src/services/GameFactsService.ts
+++ b/apps/demo-game/src/services/GameFactsService.ts
@@ -17,6 +17,7 @@ export function update(
     baseFacts,
     (draft: OutputGameFacts) => {
       draft.updatedGameFacts = {
+        ...facts,
         myInt: facts.myInt + 1,
       }
     }

--- a/packages/platform/src/services/GameService.ts
+++ b/packages/platform/src/services/GameService.ts
@@ -795,7 +795,8 @@ export async function activateNextSegment(
         segmentIx: nextSegmentIx, // TODO(JJ): Double-check if this is right
       })
 
-      if (updatedGameFacts && currentSegmentIx >= 0) {
+      const isVeryFirst = currentPeriodIx === 0 && currentSegmentIx === -1
+      if (updatedGameFacts && !isVeryFirst) {
         game.facts = updatedGameFacts
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the game data update mechanism to consistently retain all relevant details.
  - Adjusted the update conditions to ensure game data updates occur only after the initial stage of play.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->