### PR TITLE
fix(platform): make sure period_start result has segment index for results before se…

### DIFF
--- a/packages/platform/src/services/GameService.ts
+++ b/packages/platform/src/services/GameService.ts
@@ -1223,6 +1223,7 @@ export function computePeriodStartResults(
         return {
           type: DB.PlayerResultType.PERIOD_START,
           periodIx: currentPeriodIx,
+          segmentIx: -1,
           facts,
           player: {
             connect: {
@@ -1264,6 +1265,7 @@ export function computePeriodStartResults(
     return {
       type: DB.PlayerResultType.PERIOD_START,
       periodIx: nextPeriodIx,
+      segmentIx: -1,
       facts,
       player: {
         connect: {
@@ -1317,7 +1319,8 @@ export async function computePeriodEndResults(
   const results = activeSegmentResults
     .filter((result) => result.type === DB.PlayerResultType.SEGMENT_END)
     .map((result, ix, allResults) => {
-      const segmentEndResults = perPlayer[result.playerId].segmentEndResults
+      const segmentEndResultsLocal =
+        perPlayer[result.playerId].segmentEndResults
       const consolidationDecisions =
         perPlayer[result.playerId].consolidationDecisions
       const {
@@ -1325,7 +1328,7 @@ export async function computePeriodEndResults(
         actions,
         events,
       } = services.PeriodResult.end(result.facts, {
-        segmentEndResults,
+        segmentEndResults: segmentEndResultsLocal,
         gameFacts: game.facts,
         periodFacts,
         segmentFacts,

--- a/packages/platform/src/services/PlayService.ts
+++ b/packages/platform/src/services/PlayService.ts
@@ -355,7 +355,7 @@ export async function getPlayerResult(args: GetPlayerResultArgs, ctx: Context) {
     segmentCount: period.segments.length,
   }))
 
-  // We filter up to the active period (and active segemnt) - future periods
+  // We filter up to the active period (and active segment) - future periods
   // should not be visible to the user
   const activePeriodIx = currentGame.activePeriodIx
   currentGame.periods = currentGame.periods.filter(
@@ -370,7 +370,7 @@ export async function getPlayerResult(args: GetPlayerResultArgs, ctx: Context) {
   currentGame.periods[activePeriodIx]!.segments =
     currentGame.activePeriod.segments
 
-  const previousResults = ctx.prisma.playerResult.findMany({
+  const previousResults = await ctx.prisma.playerResult.findMany({
     orderBy: {
       id: 'asc',
     },
@@ -392,7 +392,10 @@ export async function getPlayerResult(args: GetPlayerResultArgs, ctx: Context) {
         periodIx: currentGame.activePeriodIx,
         segmentIx: currentGame.activePeriod.activeSegmentIx,
         playerId: args.playerId,
-        type: DB.PlayerResultType.SEGMENT_END,
+        type:
+          activePeriodIx === 0 && activeSegmentIx === -1
+            ? DB.PlayerResultType.PERIOD_START
+            : DB.PlayerResultType.SEGMENT_END,
       },
     },
     include: {
@@ -406,7 +409,7 @@ export async function getPlayerResult(args: GetPlayerResultArgs, ctx: Context) {
     },
   })
 
-  const transactions = ctx.prisma.playerAction.findMany({
+  const transactions = await ctx.prisma.playerAction.findMany({
     where: {
       player: {
         id: args.playerId,


### PR DESCRIPTION
…gments start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the logic for fetching player results to accurately distinguish between period start and segment end states.
	- Ensured asynchronous data fetching operations are properly awaited for more reliable results.
	- Fixed a typo in a comment for improved code clarity.

- **Refactor**
	- Improved internal variable naming to enhance code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->