### PR TITLE
fix: stabilize platform realtime pubsub events

### DIFF
--- a/packages/platform/public/ops/QResult.graphql
+++ b/packages/platform/public/ops/QResult.graphql
@@ -55,17 +55,4 @@ query Result {
     type
     facts
   }
-
-  questAchievements {
-    id
-    name
-    namesByRole
-    description
-    descriptionsByRole
-    image
-    when
-    scope
-    activePeriods
-    reward
-  }
 }

--- a/packages/platform/src/lib/pubsub.ts
+++ b/packages/platform/src/lib/pubsub.ts
@@ -27,15 +27,32 @@ function getOrCreatePubSub() {
   return instance
 }
 
-export let pubSub = getOrCreatePubSub()
+let currentPubSub = getOrCreatePubSub()
+
+export let pubSub = currentPubSub
+
+export function getPubSub() {
+  if (process.env.NODE_ENV !== 'production') {
+    const cached = (globalThis as any)[PUBSUB_KEY]
+    if (cached) {
+      currentPubSub = cached
+      pubSub = cached
+      return cached
+    }
+    ;(globalThis as any)[PUBSUB_KEY] = currentPubSub
+  }
+
+  return currentPubSub
+}
 
 /**
  * Replace the default in-memory pubSub with one backed by a custom event target
  * (e.g. Redis). Must be called before the first GraphQL request is handled.
  */
 export function configurePubSub(eventTarget: EventTarget) {
-  pubSub = createPubSub<PubSubChannels>({ eventTarget })
+  currentPubSub = createPubSub<PubSubChannels>({ eventTarget })
+  pubSub = currentPubSub
   if (process.env.NODE_ENV !== 'production') {
-    ;(globalThis as any)[PUBSUB_KEY] = pubSub
+    ;(globalThis as any)[PUBSUB_KEY] = currentPubSub
   }
 }

--- a/packages/platform/src/services/EventService.ts
+++ b/packages/platform/src/services/EventService.ts
@@ -1,11 +1,56 @@
 import * as DB from '@prisma/client'
-import { pubSub } from '../lib/pubsub.js'
+import { getPubSub } from '../lib/pubsub.js'
 import { BaseUserNotificationType as UserNotificationType } from '../types.js'
 import type {
   BaseGlobalNotificationType,
   Event as PlatformEvent,
 } from '../types.js'
 import log from '../lib/logger.js'
+
+export const realtimeGameStateSelect = {
+  status: true,
+  activePeriodIx: true,
+  version: true,
+  activePeriod: {
+    select: {
+      activeSegmentIx: true,
+    },
+  },
+} as const
+
+type RealtimeGameState = {
+  status: DB.GameStatus
+  activePeriodIx: number
+  version: number
+  activePeriod: {
+    activeSegmentIx: number | null
+  } | null
+}
+
+export async function getGameRealtimeState(
+  prisma: DB.PrismaClient,
+  gameId: number
+) {
+  return prisma.game.findUnique({
+    where: { id: gameId },
+    select: realtimeGameStateSelect,
+  }) as Promise<RealtimeGameState | null>
+}
+
+export function buildGameRealtimeFacts(
+  gameId: number,
+  gameState: RealtimeGameState | null,
+  extraFacts: Record<string, unknown> = {}
+) {
+  return {
+    ...extraFacts,
+    gameId,
+    version: gameState?.version ?? 0,
+    status: gameState?.status ?? null,
+    activePeriodIx: gameState?.activePeriodIx ?? null,
+    activeSegmentIx: gameState?.activePeriod?.activeSegmentIx ?? null,
+  }
+}
 
 export async function receiveEvents({ events, ctx, prisma }) {
   if (!Array.isArray(events) || events.length === 0) return []
@@ -290,8 +335,12 @@ export async function receiveEvent(
 
 export function publishGlobalNotification(event: PlatformEvent<any>) {
   try {
-    pubSub.publish('global:events', event)
-    log.info('[EventService] Successfully published to "global:events".')
+    getPubSub().publish('global:events', event)
+    log.info('[EventService] Published to "global:events".', {
+      gameId: event?.facts?.gameId ?? null,
+      type: event?.type ?? null,
+      version: event?.facts?.version ?? null,
+    })
   } catch (e) {
     log.error('[EventService] Error during pubSub.publish:', e)
   }
@@ -303,6 +352,6 @@ export function publishUserNotification(
 ) {
   if (events && events.length > 0) {
     // console.log(events)
-    pubSub.publish('user:events', ctx.user.sub, events as any)
+    getPubSub().publish('user:events', ctx.user.sub, events as any)
   }
 }

--- a/packages/platform/src/services/GameService.ts
+++ b/packages/platform/src/services/GameService.ts
@@ -400,6 +400,7 @@ export async function activateNextPeriod(
   // })
 
   let finalTransactionResult
+  let didUpdate = false
   switch (game.status) {
     // SCHEDULED -> PREPARATION
     // if the game is scheduled, initialize period results and move to PREPARATION
@@ -448,7 +449,12 @@ export async function activateNextPeriod(
               },
             },
           },
-          data: gameData,
+          data: {
+            ...gameData,
+            version: {
+              increment: 1,
+            },
+          },
         }),
 
         ctx.prisma.period.update({
@@ -467,6 +473,7 @@ export async function activateNextPeriod(
 
         ...extras,
       ])
+      didUpdate = true
 
       break
     }
@@ -514,8 +521,13 @@ export async function activateNextPeriod(
               periodIx: currentPeriodIx,
             })
 
-          await tx.game.update({
-            data: { status: DB.GameStatus.CONSOLIDATION },
+          const updatedGame = await tx.game.update({
+            data: {
+              status: DB.GameStatus.CONSOLIDATION,
+              version: {
+                increment: 1,
+              },
+            },
             include: {
               periods: {
                 include: {
@@ -572,9 +584,12 @@ export async function activateNextPeriod(
           for (const extra of extras) {
             await extra
           }
+
+          return updatedGame
         },
         { timeout: 120000 }
       )
+      didUpdate = true
 
       break
     }
@@ -671,10 +686,15 @@ export async function activateNextPeriod(
           })
 
           // update the status and active period of the current game
-          await tx.game.update({
+          const updatedGame = await tx.game.update({
             where: { id: gameId },
             include: { periods: { include: { segments: true } } },
-            data: gameData,
+            data: {
+              ...gameData,
+              version: {
+                increment: 1,
+              },
+            },
           })
 
           // create PERIOD_END results based on the previous SEGMENT_END results
@@ -693,9 +713,12 @@ export async function activateNextPeriod(
           for (const extra of extras) {
             await extra
           }
+
+          return updatedGame
         },
         { timeout: 120000 }
       )
+      didUpdate = true
 
       break
     }
@@ -758,7 +781,12 @@ export async function activateNextPeriod(
               },
             },
           },
-          data: { status: DB.GameStatus.PREPARATION },
+          data: {
+            status: DB.GameStatus.PREPARATION,
+            version: {
+              increment: 1,
+            },
+          },
         }),
 
         // create PERIOD_START results based on the previous PERIOD_END results
@@ -784,6 +812,7 @@ export async function activateNextPeriod(
 
         ...extras,
       ])
+      didUpdate = true
 
       break
     }
@@ -796,25 +825,16 @@ export async function activateNextPeriod(
       return null
   }
 
-  if (finalTransactionResult) {
-    // Re-fetch game state to ensure event reflects committed data
-    const gameAfterUpdate = await ctx.prisma.game.findUnique({
-      where: { id: gameId },
-      // Include what's necessary for the event payload
-      select: {
-        status: true,
-        activePeriodIx: true,
-      },
-    })
+  if (didUpdate) {
+    const gameAfterUpdate = await EventService.getGameRealtimeState(
+      ctx.prisma,
+      gameId
+    )
 
     if (gameAfterUpdate) {
       const eventToPublish: PlatformEvent<BaseGlobalNotificationType> = {
         type: BaseGlobalNotificationType.PERIOD_ACTIVATED,
-        facts: {
-          gameId: gameId,
-          status: gameAfterUpdate.status,
-          activePeriodIx: gameAfterUpdate.activePeriodIx,
-        },
+        facts: EventService.buildGameRealtimeFacts(gameId, gameAfterUpdate),
       }
       EventService.publishGlobalNotification(eventToPublish)
       log.info(
@@ -867,6 +887,7 @@ export async function activateNextSegment(
   // })
 
   let finalTransactionResult
+  let didUpdate = false
   switch (game.status) {
     // PREPARATION -> RUNNING
     // PAUSED -> RUNNING
@@ -883,7 +904,7 @@ export async function activateNextSegment(
 
           // }
 
-          await tx.game.update({
+          const updatedGame = await tx.game.update({
             where: {
               id: gameId,
             },
@@ -897,6 +918,9 @@ export async function activateNextSegment(
             },
             data: {
               status: DB.GameStatus.RUNNING,
+              version: {
+                increment: 1,
+              },
               // TODO(JJ): We need this to be updated
               // activeSegmentIx: nextSegmentIx,
             },
@@ -949,9 +973,12 @@ export async function activateNextSegment(
           for (const extra of extras) {
             await extra
           }
+
+          return updatedGame
         },
         { timeout: 120000 }
       )
+      didUpdate = true
 
       break
     }
@@ -992,7 +1019,7 @@ export async function activateNextSegment(
             services,
           })
 
-          await tx.game.update({
+          const updatedGame = await tx.game.update({
             where: { id: gameId },
             include: {
               periods: {
@@ -1002,7 +1029,12 @@ export async function activateNextSegment(
               },
               players: true,
             },
-            data: { status: DB.GameStatus.PAUSED },
+            data: {
+              status: DB.GameStatus.PAUSED,
+              version: {
+                increment: 1,
+              },
+            },
           })
           await tx.periodSegment.update({
             where: {
@@ -1036,9 +1068,12 @@ export async function activateNextSegment(
           for (const extra of extras) {
             await extra
           }
+
+          return updatedGame
         },
         { timeout: 120000 }
       )
+      didUpdate = true
 
       break
     }
@@ -1049,29 +1084,16 @@ export async function activateNextSegment(
       )
       return null
   }
-  if (finalTransactionResult) {
-    const gameAfterUpdate = await ctx.prisma.game.findUnique({
-      where: { id: gameId },
-      select: {
-        status: true,
-        activePeriodIx: true,
-        activePeriod: {
-          include: {
-            activeSegment: true,
-          },
-        },
-      },
-    })
+  if (didUpdate) {
+    const gameAfterUpdate = await EventService.getGameRealtimeState(
+      ctx.prisma,
+      gameId
+    )
 
     if (gameAfterUpdate && gameAfterUpdate.activePeriod) {
       const eventToPublish: PlatformEvent<BaseGlobalNotificationType> = {
         type: BaseGlobalNotificationType.SEGMENT_ACTIVATED,
-        facts: {
-          gameId: gameId,
-          status: gameAfterUpdate.status,
-          activePeriodIx: gameAfterUpdate.activePeriodIx,
-          activeSegmentIx: gameAfterUpdate.activePeriod.activeSegmentIx,
-        },
+        facts: EventService.buildGameRealtimeFacts(gameId, gameAfterUpdate),
       }
       EventService.publishGlobalNotification(eventToPublish)
       log.info(

--- a/packages/platform/src/services/PlayService.ts
+++ b/packages/platform/src/services/PlayService.ts
@@ -774,13 +774,16 @@ export async function updateReadyState(args, ctx: Context) {
   })
 
   if (typeof ctx.user.gameId === 'number') {
+    const gameState = await EventService.getGameRealtimeState(
+      ctx.prisma,
+      ctx.user.gameId
+    )
     const eventToPublish: PlatformEvent<BaseGlobalNotificationType> = {
       type: BaseGlobalNotificationType.GAME_STATE_UPDATED,
-      facts: {
-        gameId: ctx.user.gameId,
+      facts: EventService.buildGameRealtimeFacts(ctx.user.gameId, gameState, {
         playerId: updatedPlayer.id,
         isReady: updatedPlayer.isReady,
-      },
+      }),
     }
     EventService.publishGlobalNotification(eventToPublish)
     log.info(
@@ -813,28 +816,35 @@ export async function addCountdown(args, ctx: Context) {
 
   const countdownDurationMs = args.seconds * 1000
   const newExpiresAt = dayjs().add(countdownDurationMs, 'ms').toDate()
-  await ctx.prisma.periodSegment.update({
-    where: {
-      id: currentGame.activePeriod.activeSegment.id,
-    },
-    data: {
-      countdownExpiresAt: newExpiresAt,
-      countdownDurationMs,
-    },
-  })
+  const [, updatedGame] = await ctx.prisma.$transaction([
+    ctx.prisma.periodSegment.update({
+      where: {
+        id: currentGame.activePeriod.activeSegment.id,
+      },
+      data: {
+        countdownExpiresAt: newExpiresAt,
+        countdownDurationMs,
+      },
+    }),
+    ctx.prisma.game.update({
+      where: { id: args.gameId },
+      data: {
+        version: {
+          increment: 1,
+        },
+      },
+      select: EventService.realtimeGameStateSelect,
+    }),
+  ])
 
   const eventToPublish: PlatformEvent<BaseGlobalNotificationType> = {
     type: BaseGlobalNotificationType.COUNTDOWN_UPDATED,
-    facts: {
-      gameId: args.gameId,
-      periodId: currentGame.activePeriod.id, // good to have for context
+    facts: EventService.buildGameRealtimeFacts(args.gameId, updatedGame, {
+      periodId: currentGame.activePeriod.id,
       segmentId: currentGame.activePeriod.activeSegment.id,
-      countdownExpiresAt: newExpiresAt.toISOString(), // Standard format
+      countdownExpiresAt: newExpiresAt.toISOString(),
       countdownDurationMs,
-      status: currentGame.status,
-      activePeriodIx: currentGame.activePeriodIx,
-      activeSegmentIx: currentGame.activePeriod.activeSegmentIx,
-    },
+    }),
   }
   EventService.publishGlobalNotification(eventToPublish)
   log.info(
@@ -864,22 +874,24 @@ export async function toggleSwitch(args, ctx: Context) {
     return null // Or false, depending on expected return type
   }
 
-  await ctx.prisma.game.update({
+  const updatedGame = await ctx.prisma.game.update({
     where: { id: args.gameId },
-    data: { facts: { ...(currentGame.facts as any), toggle: args.toggle } },
+    data: {
+      facts: { ...(currentGame.facts as any), toggle: args.toggle },
+      version: {
+        increment: 1,
+      },
+    },
+    select: EventService.realtimeGameStateSelect,
   })
 
   const eventToPublish: PlatformEvent<BaseGlobalNotificationType> = {
     type: BaseGlobalNotificationType.SWITCH_TOGGLED,
-    facts: {
-      gameId: args.gameId,
+    facts: EventService.buildGameRealtimeFacts(args.gameId, updatedGame, {
       periodId: currentGame.activePeriod.id,
       segmentId: currentGame.activePeriod.activeSegment.id,
-      status: currentGame.status,
-      activePeriodIx: currentGame.activePeriodIx,
-      activeSegmentIx: currentGame.activePeriod.activeSegmentIx,
       toggle: args.toggle,
-    },
+    }),
   }
   EventService.publishGlobalNotification(eventToPublish)
   log.info(

--- a/packages/platform/src/types/Game.ts
+++ b/packages/platform/src/types/Game.ts
@@ -19,6 +19,7 @@ export const Game = objectType({
       type: GameStatus,
     })
     t.nonNull.string('name')
+    t.nonNull.int('version')
     t.int('activePeriodIx')
     t.field('activePeriod', {
       type: Period,


### PR DESCRIPTION
## Summary
This changeset hardens the platform side of realtime game-state delivery so player clients can react to admin lifecycle changes reliably, including in scaled Redis-backed deployments.

The core issue was that admin transitions were not producing a consistently ordered, durable realtime signal. Several lifecycle mutations updated the game state inside callback-style Prisma transactions, but the publish path only ran when the transaction returned a truthy value. Those callback transactions were committing successfully while returning `undefined`, which meant the state changed in the database but no global event was published. On the player side, that translated into stale routes such as staying on paused or results until a manual reload.

A second issue was pubsub backend drift. In development and scaled setups, code paths could capture an outdated in-memory pubsub instance instead of the configured Redis-backed instance. That made pubsub behavior sensitive to module initialization order and hot reload behavior.

## What Changed
This PR makes the platform emit a stable, versioned realtime signal for every game-shell state change.

`Game.version` is now exposed in the GraphQL type so consumers can order updates monotonically.

`EventService` now provides a small realtime game-state selector plus helpers to build the event facts payload from committed database state. Global publish logging was also tightened to include `gameId`, `type`, and `version` for observability.

`GameService` now increments `game.version` on lifecycle mutations that affect the player shell, including segment and period transitions. The publish path no longer depends on the transaction return value being truthy. Instead, it publishes after any committed update, re-fetches the committed game state, and emits a versioned event payload. The callback-transaction branches also return the updated game again so the mutation contract remains coherent for callers.

`PlayService` now publishes the same versioned realtime facts for countdown and switch updates, and increments `game.version` when those shell-visible updates occur.

The pubsub singleton in `src/lib/pubsub.ts` was hardened with `getPubSub()` so request handlers and event publishers always resolve the active backend rather than relying on a stale imported instance. This is the key piece that keeps Redis-backed pubsub and in-memory pubsub behavior aligned.

Finally, `packages/platform/public/ops/QResult.graphql` drops `questAchievements` from `Result` so downstream consumers can move route-critical realtime state off the heavier result query.

## User Impact
With these changes, consumers can trust that admin transitions such as closing a segment, opening the next one, moving to consolidation, moving to results, and returning to preparation all produce a fresh, ordered event with the committed game version. That removes the need to rely on incidental reloads or short polling to recover from missed transitions.

## Validation
I validated this from the consuming Next app against the linked platform package with Redis pubsub enabled.

The player client automatically moved through the following sequence without a manual reload:
- running -> paused
- paused -> running
- running -> consolidation
- consolidation -> results
- results -> preparation

The player-side debug log showed ordered `event:received` entries with increasing versions, and the server log showed the Redis backend plus versioned publish metadata.

I also reran the consumer checks that cover the new realtime behavior:
- `pnpm -F @derivatives-game/next check:ts`
- `pnpm -F @derivatives-game/next test -- --testPathPattern='playerRealtime|useGameRedirects'`

## Notes
This PR intentionally focuses on the platform half of the fix. The consumer app changes that use the lightweight realtime query and versioned event handling live in the application repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Games now expose a version field for state tracking and change detection.
  * Real-time game state is now included in game events with comprehensive status and period information.

* **Improvements**
  * Game event payloads are enriched with consistent, versioned state data.
  * All game updates now properly increment version numbers for state consistency across transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->