### PR TITLE
enhance: pass validated facts to roleAssigner callback

### DIFF
--- a/packages/platform/src/services/GameService.ts
+++ b/packages/platform/src/services/GameService.ts
@@ -28,7 +28,7 @@ export async function createGame<TFacts>(
   {
     schema,
     roleAssigner,
-  }: { schema: yup.Schema<TFacts>; roleAssigner?: (ix: number) => any }
+  }: { schema: yup.Schema<TFacts>; roleAssigner?: (ix: number, facts: any) => any }
 ) {
   const validatedFacts = schema.validateSync(facts) as any
 
@@ -46,7 +46,7 @@ export async function createGame<TFacts>(
           return {
             facts: {},
             token: nanoid(),
-            role: roleAssigner ? roleAssigner(ix) : undefined,
+            role: roleAssigner ? roleAssigner(ix, validatedFacts) : undefined,
             number: playerCount - ix,
             name: `Team ${playerCount - ix}`,
             level: {

--- a/packages/platform/src/types/Mutation.ts
+++ b/packages/platform/src/types/Mutation.ts
@@ -27,7 +27,7 @@ interface GenerateBaseMutationsArgs {
   schemas?: any
   inputTypes?: any
   // TODO(JJ): return value should be unknown
-  roleAssigner?: (ix: number) => any
+  roleAssigner?: (ix: number, facts: any) => any
 }
 
 function hasCompletedCompanySetup(


### PR DESCRIPTION
## Summary

- Add `facts` as second argument to the `roleAssigner` callback in `createGame` and `generateBaseMutations`
- Passes the already-validated facts object so game implementations can assign roles based on game configuration
- Backward-compatible: existing `roleAssigner` functions that only use `ix` continue to work unchanged

## Changed files

- `packages/platform/src/types/Mutation.ts` — updated `roleAssigner` type signature
- `packages/platform/src/services/GameService.ts` — pass `validatedFacts` to `roleAssigner` call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Role assignment logic now has access to additional game context when determining player roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->