### PR TITLE
fix(demo-game): resolve react-hooks/set-state-in-effect lint debt

### DIFF
--- a/apps/demo-game/eslint.config.mjs
+++ b/apps/demo-game/eslint.config.mjs
@@ -9,17 +9,6 @@ import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
 const eslintConfig = [
   ...nextCoreWebVitals,
   {
-    // eslint-config-next 16 promotes `react-hooks/set-state-in-effect` to an
-    // error. It flags 4 pre-existing setState-in-effect patterns (cockpit,
-    // StoryElements, LearningElement) that predate this toolchain upgrade;
-    // reworking those effects is a behavior-sensitive change out of scope here
-    // (this PR is toolchain/config only). Keep them visible as warnings and fix
-    // as follow-up lint debt rather than block the new lint baseline.
-    rules: {
-      'react-hooks/set-state-in-effect': 'warn',
-    },
-  },
-  {
     // An object with only `ignores` sets global ignores. Mirrors the old
     // `ignorePatterns` (build output + generated GraphQL); node_modules is
     // ignored by flat config out of the box.

--- a/apps/demo-game/src/components/LearningElement.tsx
+++ b/apps/demo-game/src/components/LearningElement.tsx
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { LearningElementState } from '@gbl-uzh/platform'
 import { Button } from '@uzh-bf/design-system'
 import { without } from 'ramda'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import Markdown from 'react-markdown'
 import {
   AttemptLearningElementDocument,
@@ -22,9 +22,14 @@ function LearningElement({ elementId }: { elementId: string }) {
 
   const [elementState, setElementState] = useState(null)
 
-  useEffect(() => {
+  // Reset the current selection whenever the rendered element changes. Done as
+  // a render-phase reset (tracking the previous prop) rather than an effect, so
+  // it complies with react-hooks/set-state-in-effect and applies before paint.
+  const [prevElementId, setPrevElementId] = useState(elementId)
+  if (prevElementId !== elementId) {
+    setPrevElementId(elementId)
     setActiveElements([])
-  }, [elementId])
+  }
 
   const { toast } = useToast()
 

--- a/apps/demo-game/src/components/StoryElements.tsx
+++ b/apps/demo-game/src/components/StoryElements.tsx
@@ -36,6 +36,9 @@ function StoryElements({ playerState, player }: Props) {
       const unseenStoryElements = activeStoryElements.filter(
         (elem) => !visitedStoryElements?.includes(elem.id)
       )
+      // Seeds a local queue that the modal then consumes via slice(1) on close,
+      // so it is not derivable from props and cannot move to render phase.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setUnseenStoryElements(unseenStoryElements)
     }
   }, [activeStoryElements, playerState, visitedStoryElements])

--- a/apps/demo-game/src/pages/play/cockpit.tsx
+++ b/apps/demo-game/src/pages/play/cockpit.tsx
@@ -147,6 +147,16 @@ function GameLayout({ children }: { children: React.ReactNode }) {
     return strExpiresAt ? dayjs(strExpiresAt).toDate() : null
   }, [strExpiresAt])
 
+  // Re-arm the per-threshold countdown notifications whenever the countdown
+  // changes. Done as a render-phase reset (tracking the previous countdown key)
+  // rather than an effect, so it complies with react-hooks/set-state-in-effect.
+  const countdownKey = `${strExpiresAt}|${countdownDurationMs}`
+  const [prevCountdownKey, setPrevCountdownKey] = useState(countdownKey)
+  if (prevCountdownKey !== countdownKey) {
+    setPrevCountdownKey(countdownKey)
+    setCountdownNotifications({ '60': false, '180': false })
+  }
+
   useEffect(() => {
     if (!strExpiresAt) return
 
@@ -159,8 +169,6 @@ function GameLayout({ children }: { children: React.ReactNode }) {
         description: `${secondsRemaining} seconds remaining! Please press ready once you are done playing.`,
       })
     }
-
-    setCountdownNotifications({ '60': false, '180': false })
   }, [strExpiresAt, countdownDurationMs])
 
   const playerInfo = {
@@ -314,11 +322,20 @@ function Cockpit() {
     }
   )
 
-  useEffect(() => {
-    if (data?.result?.currentGame?.periods?.length > 0) {
-      setPeriod(data.result.currentGame.periods.length - 1)
+  // Default the selected period to the latest one whenever the number of
+  // periods changes (e.g. a new period is activated). Done as a render-phase
+  // update (tracking the previous count, seeded at 0 so the initial load is
+  // also covered) rather than an effect, per react-hooks/set-state-in-effect.
+  // Manual navigation via setPeriod is preserved because this only fires when
+  // the count itself changes.
+  const periodsLength = data?.result?.currentGame?.periods?.length ?? 0
+  const [prevPeriodsLength, setPrevPeriodsLength] = useState(0)
+  if (prevPeriodsLength !== periodsLength) {
+    setPrevPeriodsLength(periodsLength)
+    if (periodsLength > 0) {
+      setPeriod(periodsLength - 1)
     }
-  }, [data?.result?.currentGame?.periods?.length])
+  }
 
   if (loading) return null
   if (error) return `Error! ${error}`


### PR DESCRIPTION
## What This Fixes

eslint-config-next 16 (added in the prior toolchain-upgrade PR, merged via #150) promotes `react-hooks/set-state-in-effect` to an **error**. To unblock that merge, the rule was temporarily demoted to a `warn` in `eslint.config.mjs` with the 4 flagged sites left as follow-up lint debt.

This PR pays that debt: it restores the rule to **error** (removes the override) and reworks the 4 sites without behavior change.

1. **LearningElement** — resets the current selection when the rendered `elementId` changes. Moved from `useEffect(() => setActiveElements([]), [elementId])` to a render-phase prev-prop reset (the `useEffect` import becomes unused and is dropped). Selection now clears before paint instead of after.
2. **cockpit `GameLayout`** — re-arms the per-threshold (`60`/`180`) countdown notifications when the countdown changes. Moved to a render-phase reset keyed on `strExpiresAt|countdownDurationMs`. The "Countdown set/updated!" toast stays in its effect (effects are the right place for side effects like toasts).
3. **cockpit `Cockpit`** — defaults the selected `period` to the latest one when the number of periods changes. Moved to a render-phase periods-length tracker, **seeded at 0** so the initial data load is still covered, and gated on count change so manual `setPeriod` navigation is preserved.
4. **StoryElements** — kept as an effect with a per-line `eslint-disable` + rationale. It seeds a local `unseenStoryElements` queue that the modal then *consumes* via `slice(1)` on close, so it is genuine local state, not derivable from props, and cannot move to render phase.

## How It Works

The render-phase pattern (React's documented "adjusting state when a prop changes" approach) tracks the previous value in state and compares during render; when it differs it updates both the tracker and the derived state. React re-renders immediately without committing the intermediate UI, so there is no extra paint and no behavior change versus the prior effect — only the lint-compliant timing (before paint rather than after).

## Branch Coverage

- Base: `dev` (`f4948b1`)
- Head: `825f004`
- Reviewed: 1 commit, 4 files (`eslint.config.mjs`, `LearningElement.tsx`, `StoryElements.tsx`, `cockpit.tsx`)
- Covered: rule re-enabled to error + all 4 flagged sites.

## Verification

Current head:
- `pnpm -F @gbl-uzh/demo-game lint` -> `0 errors, 13 warnings` (the 13 are pre-existing `exhaustive-deps` / `no-img-element` / `alt-text` warnings unrelated to this change; the `set-state-in-effect` rule is now error and reports nothing).

Not run (locally):
- `tsc` — this worktree does not link the `@gbl-uzh/platform` / `@gbl-uzh/ui` workspace packages, so a standalone `tsc` reports only pre-existing module-resolution noise in files unrelated to this diff. The authoritative typecheck runs in the CI build (which builds platform first) — see this PR's `demo-game` workflow.

## Review Focus

- The three render-phase conversions are behavior-preserving but timing-sensitive. Worth a quick runtime sanity check (see below) since the originals ran post-paint.
- `Cockpit` period tracker is seeded at `0` (not the current length) specifically so a cache-hit first render still selects the latest period.

## Blocking Before Merge

- [ ] Manual runtime smoke (the conversions are not covered by automated tests):
  - Learning element: switching between elements clears the previous selection.
  - Countdown: starting/updating a countdown re-enables the 1-min/3-min "less than N min remaining" notifications.
  - Period: opening the cockpit defaults to the latest period; manual period navigation is not snapped back.
  - Story modal: unseen story elements still appear and advance one-by-one on "Continue"/close.

## Follow-Up After Merge

None.