### PR TITLE
docs(demo-game): update auth setup guide

### DIFF
--- a/apps/demo-game/.env.local.template
+++ b/apps/demo-game/.env.local.template
@@ -1,9 +1,10 @@
 # generate using `openssl rand -base64 32`
 NEXTAUTH_SECRET=
 
-# create a new app and client secret here: https://github.com/settings/apps
-# homepage url: http://localhost:3000
-# callback url: http://localhost:3000/api/auth/callback/auth0
+# Auth0 application settings for manual local setup.
+# Application login URL: http://localhost:3000/admin/login
+# Allowed callback URL: http://localhost:3000/api/auth/callback/auth0
+# Allowed logout URL: http://localhost:3000/
 AUTH0_CLIENT_ID=
 AUTH0_CLIENT_SECRET=
 AUTH0_ISSUER=https://

--- a/apps/demo-game/.env.local.template
+++ b/apps/demo-game/.env.local.template
@@ -1,7 +1,8 @@
 # generate using `openssl rand -base64 32`
 NEXTAUTH_SECRET=
 
-# Auth0 application settings for manual local setup.
+# Auth0 application settings for manual local setup without the
+# devcontainer/devrouter mocked OIDC service.
 # Application login URL: http://localhost:3000/admin/login
 # Allowed callback URL: http://localhost:3000/api/auth/callback/auth0
 # Allowed logout URL: http://localhost:3000/

--- a/apps/demo-game/README.md
+++ b/apps/demo-game/README.md
@@ -4,16 +4,27 @@ This is a step by step explanation on how to implement a game using the uzh-gbl-
 
 ## Getting started
 
-### Github authentification:
+### Authentication
 
-1. Duplicate ``.env.local.template`` and rename it to ``.env.local``
-2. On github navigate to settings -> developer settings -> Github Apps -> New Github app. Then use the following settings:
-    - Homepage URL: http://localhost:3000/
-    - Callback URL: http://localhost:3000/api/auth/callback/github
-    - Disable webhooks
-3. Then in your app settings copy the Client ID key which looks somethings like  Iv1.1234... and paste it to .env.local after GITHUB_ID=
-4. Click generate a new client secret and paste it to GITHUB_SECRET=
-5. Generate a new cryptographically safe string and paste it to NEXTAUTH_SECRET= (You can use any string you want but it is recommended to use a cryptographically safe string)
+Admin login uses the NextAuth Auth0 provider.
+
+For the devcontainer/devrouter setup, no real Auth0 application is needed. The
+committed devcontainer environment points `AUTH0_ISSUER` at the local
+`mock-oauth2-server` sidecar, so admin login works through the routed local OIDC
+mock at `https://oidc.demo-game.localhost/default`.
+
+For a manual local setup without the devcontainer:
+
+1. Duplicate ``.env.local.template`` and rename it to ``.env.local``.
+2. Create an Auth0 application and configure:
+    - Application login URL: http://localhost:3000/admin/login
+    - Allowed callback URL: http://localhost:3000/api/auth/callback/auth0
+    - Allowed logout URL: http://localhost:3000/
+3. Copy the Auth0 client ID to `AUTH0_CLIENT_ID=`.
+4. Copy the Auth0 client secret to `AUTH0_CLIENT_SECRET=`.
+5. Copy the Auth0 issuer URL to `AUTH0_ISSUER=`.
+6. Generate a cryptographically safe string and paste it to `NEXTAUTH_SECRET=`
+   (for example with `openssl rand -base64 32`).
 
 
 ### Dependencies

--- a/apps/demo-game/README.md
+++ b/apps/demo-game/README.md
@@ -6,14 +6,15 @@ This is a step by step explanation on how to implement a game using the uzh-gbl-
 
 ### Authentication
 
-Admin login uses the NextAuth Auth0 provider.
+Admin login uses the NextAuth Auth0 provider in the app code.
 
-For the devcontainer/devrouter setup, no real Auth0 application is needed. The
-committed devcontainer environment points `AUTH0_ISSUER` at the local
-`mock-oauth2-server` sidecar, so admin login works through the routed local OIDC
-mock at `https://oidc.demo-game.localhost/default`.
+Local development through devcontainer/devrouter uses mocked OIDC, not real
+Auth0. The committed devcontainer environment points `AUTH0_ISSUER` at the local
+`mock-oauth2-server` sidecar, so admin login works through the routed local mock
+issuer at `https://oidc.demo-game.localhost/default`.
 
-For a manual local setup without the devcontainer:
+Only use a real Auth0 application for a manual local setup without the
+devcontainer/devrouter mock:
 
 1. Duplicate ``.env.local.template`` and rename it to ``.env.local``.
 2. Create an Auth0 application and configure:


### PR DESCRIPTION
## What This Fixes

This PR updates the demo-game authentication docs after the Playwright/OIDC merge:

1. Replaces stale GitHub OAuth setup steps in `apps/demo-game/README.md` with Auth0 setup.
2. Makes local dev auth explicit: devcontainer/devrouter uses the local `mock-oauth2-server` OIDC sidecar, not a real Auth0 app.
3. Updates `.env.local.template` comments to match the Auth0 callback URL and issuer variables.

## Branch Coverage

- Base: `dev`
- Head: `fac04533`
- Reviewed: 2 commits, 2 files changed, 27 insertions, 13 deletions.

## Verification

Current head:
- `git diff --check -- apps/demo-game/README.md apps/demo-game/.env.local.template` -> passed.

Not run:
- Runtime tests; docs/comment-only change.

## Blocking Before Merge

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the demo game authentication setup instructions for local development.
  * Clarified the required local login, callback, and logout URLs.
  * Replaced the previous GitHub-based authentication steps with Auth0 configuration details, including the needed environment values and secret setup.
  * Added guidance for using the mocked local identity provider in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->