### PR TITLE
enhance(devcontainer): adopt managed devrouter workspaces

### DIFF
--- a/.agents/skills/devrouter/SKILL.md
+++ b/.agents/skills/devrouter/SKILL.md
@@ -127,13 +127,15 @@ Config-level `envMap` on dependency references aliases per-dep vars to app-expec
 
 ## Workspace isolation (parallel git worktrees / agents)
 
-Run several worktrees of one repo in parallel without host/route collisions. A **workspace token** is a persisted identity spanning the DevPod id, devrouter routes, `${WORKSPACE}` proxy upstreams, and devcontainer aliases.
+Run several worktrees of one repo in parallel without host/route collisions. A **workspace token** spans the DevPod id, devrouter routes, `${WORKSPACE}` proxy upstreams, and devcontainer aliases.
 
-- **Identity**: each linked worktree stores one authoritative identity in Git metadata. First use reuses an exact-path DevPod or derives a sanitized branch/path slug. Later flags or `DEVROUTER_WORKSPACE` may repeat the identity but cannot rename it. Ambiguous identities fail closed. The primary checkout remains non-namespaced.
+- **Identity**: each managed linked worktree stores a local token in Git metadata plus a durable owner record in the repository's Git common directory. The record survives linked-worktree removal and binds the exact path to its DevPod ID. First use reuses an exact-path DevPod or derives a sanitized branch/path slug. Later flags or `DEVROUTER_WORKSPACE` may repeat the identity but cannot rename it. Ambiguous identities fail closed. The primary checkout remains non-namespaced.
 - **When active**: hosts auto-namespace (`web.localhost` → `web.<ws>.localhost`), `${WORKSPACE}` in `upstream` is substituted with the token, and the docker `router` key is suffixed per workspace. The runtime config is computed in memory only — the committed `.devrouter.yml` is never rewritten.
 - **TLS**: namespaced hosts (`web.<ws>.localhost`) are not covered by the `*.localhost` wildcard; devrouter auto-extends the mkcert cert SANs for active hosts when TLS is enabled.
 - **devcontainer integration**: managed scaffolds list the base compose file, then `${localEnv:DEVCONTAINER_COMPOSE_OVERLAY:docker-compose.default.yml}`; custom repositories may keep another default overlay. Selecting `.devcontainer/docker-compose.devrouter.yml` for linked worktrees must pass `WORKSPACE` and `DEVROUTER_WORKSPACE` across the combined base/overlay config and bind-mount `${DEVROUTER_GIT_COMMON_DIR}` to the same absolute app-container path. The app exposes `${WORKSPACE}-app`; the proxy uses `upstream: ${WORKSPACE}-app:<port>`.
-- **Lifecycle**: `devrouter workspace up <branch>` creates and starts a new worktree under the repository's ignored `trees/<workspace>` directory; `devrouter workspace ensure .` is the canonical startup/reconciliation command in an existing linked worktree; `workspace ls` lists identity/route state; `workspace down` serializes teardown with ensure. Ensure proves exact DevPod ownership, overlay/Git mounts, env, aliases, health, Git, HTTP route reachability, and unique running TCP upstream ownership before success, with one bounded recreate for stale state.
+- **Lifecycle**: `workspace up` creates and starts a worktree; `workspace ensure .` starts/reconciles an existing linked worktree; `workspace ls` reports owner/Git/DevPod/route state; `workspace stop` stops DevPod/routes but keeps checkout, record, and data; full `workspace down` deletes runtime/routes and removes only a clean, unlocked worktree, then its record; `down --keep-worktree` keeps checkout and record. Dirty or locked full down fails before side effects.
+- **Cleanup**: owner status is `present`, `missing`, `locked`, or `conflict`. `workspace gc` is a dry-run report; `--yes` deletes only exact ledger-owned missing/prunable resources and their records. GC never removes Git worktrees, branches, or prune state. Git has no worktree-removal hook.
+- **Boundary**: workspace commands require Git. Normal config, app, status, and doctor flows remain usable from a `.devrouter.yml` folder without `.git`.
 
 ## Secret manager interop (Infisical/Doppler)
 
@@ -204,8 +206,10 @@ Run several worktrees of one repo in parallel without host/route collisions. A *
 - `devrouter app rm <name> [--keep-config]`: remove app entry (`--keep-config` frees only the live route/hostname, leaves `.devrouter.yml` untouched)
 - `devrouter workspace up <branch> [--path <dir>] [--no-devpod] [--open]`: create a worktree and start/prove it unless create-only mode is requested
 - `devrouter workspace ensure [path] [--open]`: start/reconcile and prove an existing linked worktree environment
-- `devrouter workspace ls [--json]`: list git worktrees with workspace token + route count
-- `devrouter workspace down <workspace|branch> [--keep-worktree] [--keep-devpod]`: free routes + stop devpod + remove worktree
+- `devrouter workspace ls [--json]`: list ownership, Git, DevPod, route, path, and branch evidence
+- `devrouter workspace stop <workspace|branch>`: stop DevPod and routes; preserve checkout, owner record, and data
+- `devrouter workspace down <workspace|branch> [--keep-worktree]`: delete runtime/routes and optionally remove the clean worktree and record
+- `devrouter workspace gc [--json] [--yes]`: report missing owners by default; apply exact eligible cleanup with `--yes`
 
 ## Validation workflow
 

--- a/.agents/skills/devrouter/SKILL.md
+++ b/.agents/skills/devrouter/SKILL.md
@@ -127,13 +127,13 @@ Config-level `envMap` on dependency references aliases per-dep vars to app-expec
 
 ## Workspace isolation (parallel git worktrees / agents)
 
-Run several worktrees of one repo in parallel without host/route collisions. A **workspace token** is a single identity spanning three layers: the devpod workspace id (`devpod up --id <ws>`), the routes devrouter registers, and the `${WORKSPACE}` placeholder in `.devrouter.yml` upstreams + the devcontainer compose network alias.
+Run several worktrees of one repo in parallel without host/route collisions. A **workspace token** is a persisted identity spanning the DevPod id, devrouter routes, `${WORKSPACE}` proxy upstreams, and devcontainer aliases.
 
-- **Token resolution** (precedence): `--workspace <slug>` flag > `DEVROUTER_WORKSPACE` env var > auto-derived from a linked git worktree branch (sanitized: lowercase, non-alphanumeric → `-`, capped at 32 chars) > none. The primary checkout resolves to no token and routes exactly as before (back-compatible).
+- **Identity**: each linked worktree stores one authoritative identity in Git metadata. First use reuses an exact-path DevPod or derives a sanitized branch/path slug. Later flags or `DEVROUTER_WORKSPACE` may repeat the identity but cannot rename it. Ambiguous identities fail closed. The primary checkout remains non-namespaced.
 - **When active**: hosts auto-namespace (`web.localhost` → `web.<ws>.localhost`), `${WORKSPACE}` in `upstream` is substituted with the token, and the docker `router` key is suffixed per workspace. The runtime config is computed in memory only — the committed `.devrouter.yml` is never rewritten.
 - **TLS**: namespaced hosts (`web.<ws>.localhost`) are not covered by the `*.localhost` wildcard; devrouter auto-extends the mkcert cert SANs for active hosts when TLS is enabled.
-- **devcontainer integration**: the devcontainer compose service exposes a devnet alias `${WORKSPACE}-app` (default `WORKSPACE=<project>` in `devcontainer.env`); the proxy app uses `upstream: ${WORKSPACE}-app:<port>`. Workspace `feat-a` → alias `feat-a-app`, host `app.feat-a.localhost`.
-- **Lifecycle**: `devrouter workspace up <branch>` (create worktree + devpod + routes), `devrouter workspace ls` (list worktrees/tokens/route counts), `devrouter workspace down <workspace|branch>` (free routes by state-file workspace tag + stop devpod + remove worktree). `devrouter doctor` reports orphaned workspace proxy routes whose worktree dir was removed without `devrouter workspace down`.
+- **devcontainer integration**: managed scaffolds list the base compose file, then `${localEnv:DEVCONTAINER_COMPOSE_OVERLAY:docker-compose.default.yml}`; custom repositories may keep another default overlay. Selecting `.devcontainer/docker-compose.devrouter.yml` for linked worktrees must pass `WORKSPACE` and `DEVROUTER_WORKSPACE` across the combined base/overlay config and bind-mount `${DEVROUTER_GIT_COMMON_DIR}` to the same absolute app-container path. The app exposes `${WORKSPACE}-app`; the proxy uses `upstream: ${WORKSPACE}-app:<port>`.
+- **Lifecycle**: `devrouter workspace up <branch>` creates and starts a new worktree under the repository's ignored `trees/<workspace>` directory; `devrouter workspace ensure .` is the canonical startup/reconciliation command in an existing linked worktree; `workspace ls` lists identity/route state; `workspace down` serializes teardown with ensure. Ensure proves exact DevPod ownership, overlay/Git mounts, env, aliases, health, Git, HTTP route reachability, and unique running TCP upstream ownership before success, with one bounded recreate for stale state.
 
 ## Secret manager interop (Infisical/Doppler)
 
@@ -202,7 +202,8 @@ Run several worktrees of one repo in parallel without host/route collisions. A *
 - `devrouter app run <name> [--env <env>] [--workspace <slug>]`: run app with dependency lifecycle (--env overrides SM defaultEnv; --workspace overrides the per-workspace token)
 - `devrouter app exec <name> [--shell] [--env <env>] [--workspace <slug>] -- <cmd>`: one-shot command with resolved dep env
 - `devrouter app rm <name> [--keep-config]`: remove app entry (`--keep-config` frees only the live route/hostname, leaves `.devrouter.yml` untouched)
-- `devrouter workspace up <branch> [--path <dir>] [--no-devpod] [--open]`: create a worktree + devpod + namespaced routes
+- `devrouter workspace up <branch> [--path <dir>] [--no-devpod] [--open]`: create a worktree and start/prove it unless create-only mode is requested
+- `devrouter workspace ensure [path] [--open]`: start/reconcile and prove an existing linked worktree environment
 - `devrouter workspace ls [--json]`: list git worktrees with workspace token + route count
 - `devrouter workspace down <workspace|branch> [--keep-worktree] [--keep-devpod]`: free routes + stop devpod + remove worktree
 
@@ -216,10 +217,10 @@ For devcontainer onboarding:
 4. `devrouter repo devcontainer write --repo . --dry-run --json`
 5. `devrouter repo devcontainer write --repo . --yes`
 6. `devrouter repo devcontainer verify --repo . --json`
-7. Start the devcontainer, for example `devpod up .`
+7. In a linked worktree, start and prove the devcontainer with `devrouter workspace ensure .` (use `devpod up .` for a primary checkout)
 8. `devrouter repo devcontainer verify --repo . --live --yes --json`
 
-For existing host/docker runtime apps:
+For host/docker runtime apps only:
 
 1. `devrouter setup --repo . --yes`
 2. `devrouter doctor --repo .`

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,15 +7,23 @@ ENV PNPM_HOME="/pnpm" \
     DEBIAN_FRONTEND=noninteractive
 
 # Runtime tools: git (repo ops), openssl/ca-certificates (Prisma + TLS),
-# procps (pgrep for the dev-server guard), curl (healthchecks).
+# procps/util-linux (devrouter process ownership), curl (healthchecks), and tar
+# (extracting the pinned devrouter process helper).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        git openssl ca-certificates procps curl \
+        git openssl ca-certificates procps util-linux curl tar \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin pnpm to the repo's packageManager version (matches the prod Dockerfile).
 # Use npm (not corepack) to avoid corepack's stale signing-key verification.
 RUN npm install -g pnpm@11.6.0
+
+# Install only the process-lifecycle helper from the exact devrouter release.
+RUN npm pack --silent '@devrouter/cli@0.0.30' \
+    && tar -xzf 'devrouter-cli-0.0.30.tgz' --strip-components=2 \
+        -C /usr/local/bin package/bin/devrouter-process \
+    && chmod +x /usr/local/bin/devrouter-process \
+    && rm 'devrouter-cli-0.0.30.tgz'
 
 # Keep the pnpm store inside the image (not on the bind-mounted workspace), so
 # it neither pollutes the repo nor fights the host's store.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update \
 RUN npm install -g pnpm@11.6.0
 
 # Install only the process-lifecycle helper from the exact devrouter release.
-RUN npm pack --silent '@devrouter/cli@0.0.30' \
-    && tar -xzf 'devrouter-cli-0.0.30.tgz' --strip-components=2 \
+RUN npm pack --silent '@devrouter/cli@0.0.31' \
+    && tar -xzf 'devrouter-cli-0.0.31.tgz' --strip-components=2 \
         -C /usr/local/bin package/bin/devrouter-process \
     && chmod +x /usr/local/bin/devrouter-process \
-    && rm 'devrouter-cli-0.0.30.tgz'
+    && rm 'devrouter-cli-0.0.31.tgz'
 
 # Keep the pnpm store inside the image (not on the bind-mounted workspace), so
 # it neither pollutes the repo nor fights the host's store.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -51,11 +51,11 @@ Open <https://demo-game.localhost>. The dev server auto-starts in the background
 separately selects the package used consistently for Prisma copy/generate/push,
 seed, and the dev server. It defaults to `demo`; the supported values are:
 
-| Target | Package |
-| --- | --- |
-| `demo` | `@gbl-uzh/demo-game` |
+| Target         | Package                 |
+| -------------- | ----------------------- |
+| `demo`         | `@gbl-uzh/demo-game`    |
 | `central-bank` | `@gbl-uzh/central-bank` |
-| `rate-wars` | `@gbl-uzh/rate-wars` |
+| `rate-wars`    | `@gbl-uzh/rate-wars`    |
 
 Pass an explicit target when creating the DevPod workspace, for example:
 
@@ -69,17 +69,18 @@ route and database volume. Unknown targets fail before any Prisma command runs.
 
 ## How routing works
 
-The app and Postgres join the external `devnet` network with workspace-aware
-aliases (`${WORKSPACE:-demo-game}-app`, `${WORKSPACE:-demo-game}-db`).
-devrouter's Traefik (also on `devnet`) routes to them **by name over the
-network** — no published host ports. The OIDC mock shares the app container's
-netns, so it is reached on `devnet` as `${WORKSPACE:-demo-game}-app:8090`.
+The app, OIDC mock, and Postgres join the external `devnet` network with
+workspace-aware aliases (`${WORKSPACE:-demo-game}-app`,
+`${WORKSPACE:-demo-game}-oidc`, `${WORKSPACE:-demo-game}-db`). devrouter's
+Traefik (also on `devnet`) routes to them **by name over the network** — no
+published host ports. Linked worktrees namespace both the app and OIDC issuer
+hosts automatically.
 
-| What      | Host                                       | Upstream (devnet)       |
-| --------- | ------------------------------------------ | ----------------------- |
-| App       | `https://demo-game.localhost`              | `${WORKSPACE}-app:3000` |
-| OIDC mock | `https://oidc.demo-game.localhost/default` | `${WORKSPACE}-app:8090` |
-| Postgres  | `db.demo-game.localhost:5432`              | `${WORKSPACE}-db:5432`  |
+| What      | Host                                       | Upstream (devnet)        |
+| --------- | ------------------------------------------ | ------------------------ |
+| App       | `https://demo-game.localhost`              | `${WORKSPACE}-app:3000`  |
+| OIDC mock | `https://oidc.demo-game.localhost/default` | `${WORKSPACE}-oidc:8090` |
+| Postgres  | `db.demo-game.localhost:5432`              | `${WORKSPACE}-db:5432`   |
 
 Connect to the DB with direct-SSL so the TLS ClientHello carries the SNI:
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -17,9 +17,10 @@ host-port collisions** (nothing is published on the host).
 
 ## Prerequisites
 
-devrouter **≥ 0.0.23** (proxy + TCP routing). One-time host setup — must run
-**before** the container starts, because the stack joins devrouter's external
-`devnet` network and that network must already exist:
+devrouter **≥ 0.0.31** (proxy + TCP routing and managed workspace cleanup).
+One-time host setup — must run **before** the container starts, because the
+stack joins devrouter's external `devnet` network and that network must already
+exist:
 
 ```bash
 dev up && dev tls install   # Traefik + the shared `devnet` + mkcert CA (needs 80/443/5432 free)

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -26,7 +26,8 @@ NEXT_PUBLIC_APP_URL=https://demo-game.localhost
 NEXT_PUBLIC_API_URL=https://demo-game.localhost/api/graphql
 
 # --- Local OIDC (mock-oauth2-server sidecar, replaces Auth0) ---
-# Routed by devrouter (oidc.demo-game.localhost -> the app's netns :8090). The
+# Routed by devrouter (oidc.demo-game.localhost -> the OIDC container's
+# workspace-scoped devnet alias on :8090). The
 # SAME issuer host is used by the browser (authorize) and the app server
 # (discovery/token/jwks) — the app resolves it via extra_hosts -> host gateway
 # and trusts the mkcert CA via NODE_EXTRA_CA_CERTS — so the token `iss` matches.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "name": "gbl-uzh-demo-game",
-  "dockerComposeFile": ["docker-compose.yml"],
+  "dockerComposeFile": [
+    "docker-compose.yml",
+    "${localEnv:DEVCONTAINER_COMPOSE_OVERLAY:docker-compose.default.yml}"
+  ],
   "service": "app",
   "workspaceFolder": "/workspaces/gbl-uzh",
   "runServices": ["app", "postgres", "oidc"],

--- a/.devcontainer/docker-compose.default.yml
+++ b/.devcontainer/docker-compose.default.yml
@@ -1,0 +1,2 @@
+# devrouter-managed: do not edit manually
+services: {}

--- a/.devcontainer/docker-compose.devrouter.yml
+++ b/.devcontainer/docker-compose.devrouter.yml
@@ -1,0 +1,12 @@
+# devrouter-managed: do not edit manually
+# A linked worktree's .git file points at the host repository's common Git
+# directory. workspace ensure sets this absolute path before DevPod starts.
+services:
+  app:
+    environment:
+      WORKSPACE: ${WORKSPACE:-}
+      DEVROUTER_WORKSPACE: ${DEVROUTER_WORKSPACE:-}
+    volumes:
+      - type: bind
+        source: ${DEVROUTER_GIT_COMMON_DIR}
+        target: ${DEVROUTER_GIT_COMMON_DIR}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,9 +4,10 @@
 # via the shared external `devnet` network (NO published host ports → many
 # projects run at once with zero collisions). app/postgres join devnet with
 # workspace-aware aliases; devrouter's Traefik (also on devnet) routes to them BY NAME.
-# The OIDC mock shares the app's netns, so it is reached on devnet as
-# `${WORKSPACE:-demo-game}-app:8090`. `dev up` must run before the container starts so
-# `devnet` exists (external network). See `.devrouter.yml`.
+# The OIDC mock has its own workspace-aware devnet alias so recreating the app
+# container cannot strand OIDC in the old app network namespace. `dev up` must
+# run before the container starts so `devnet` exists (external network). See
+# `.devrouter.yml`.
 services:
   postgres:
     image: postgres:15
@@ -43,8 +44,8 @@ services:
       GBL_GAME_TARGET: ${GBL_GAME_TARGET:-demo}
     # No published app/OIDC ports: devrouter routes https://demo-game.localhost
     # and https://oidc.demo-game.localhost over devnet (so many projects coexist
-    # with zero host-port collisions). The OIDC mock shares this container's netns,
-    # so devrouter reaches it as `${WORKSPACE:-demo-game}-app:8090`.
+    # with zero host-port collisions). The OIDC mock has its own
+    # `${WORKSPACE:-demo-game}-oidc` alias.
     #
     # OIDC server-side reachability: the app validates the token issuer against
     # AUTH0_ISSUER and fetches discovery/
@@ -55,6 +56,7 @@ services:
     # server thus use the SAME issuer host over verified TLS → consistent `iss`.
     extra_hosts:
       - 'oidc.demo-game.localhost:host-gateway'
+      - 'oidc.demo-game.${WORKSPACE:-demo-game}.localhost:host-gateway'
     networks:
       default: {}
       devnet:
@@ -85,15 +87,16 @@ services:
       postgres:
         condition: service_healthy
 
-  # Local OIDC provider (Auth0 replacement). Shares the app container's network
-  # namespace so the issuer is identical whether reached by the app server
-  # (token/jwks) or the host browser (authorize). Routed by devrouter at
-  # https://oidc.demo-game.localhost/default (-> ${WORKSPACE:-demo-game}-app:8090 over devnet).
+  # Local OIDC provider (Auth0 replacement). Routed by devrouter so the issuer
+  # is identical whether reached by the app server (token/jwks) or host browser
+  # (authorize). Its own devnet alias survives app-container recreation.
   oidc:
     image: ghcr.io/navikt/mock-oauth2-server:2.1.11
-    network_mode: service:app
-    depends_on:
-      - app
+    networks:
+      default: {}
+      devnet:
+        aliases:
+          - ${WORKSPACE:-demo-game}-oidc
     environment:
       SERVER_PORT: '8090'
       # interactiveLogin=false -> one-click auto-login as the fixed dev admin.

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -27,12 +27,15 @@ resolve_gbl_game_target
 if [ "${GBL_DEV_MODE:-}" != "starter" ]; then
   if [ "${WORKSPACE:-demo-game}" = "demo-game" ]; then
     app_host="demo-game.localhost"
+    oidc_host="oidc.demo-game.localhost"
   else
     app_host="demo-game.${WORKSPACE}.localhost"
+    oidc_host="oidc.demo-game.${WORKSPACE}.localhost"
   fi
   export NEXTAUTH_URL="https://${app_host}"
   export NEXT_PUBLIC_APP_URL="https://${app_host}"
   export NEXT_PUBLIC_API_URL="https://${app_host}/api/graphql"
+  export AUTH0_ISSUER="https://${oidc_host}/default"
 fi
 
 # No-TTY pnpm hardening (see post-create.sh): keep the dev server from aborting on

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -41,21 +41,11 @@ fi
 export CI=true
 export npm_config_verify_deps_before_run=false
 
-if pgrep -f "pnpm.*-F ${GBL_GAME_PACKAGE} dev" >/dev/null 2>&1; then
-  echo "[post-start] ${GBL_GAME_PACKAGE} dev server already running."
-  exit 0
-fi
-if pgrep -f "next dev" >/dev/null 2>&1; then
-  echo "[post-start] Another Next dev server is already using this container; expected ${GBL_GAME_PACKAGE}." >&2
-  exit 1
-fi
-
-echo "[post-start] Starting ${GBL_GAME_PACKAGE} dev server in the background (logs: /tmp/dev.log)..."
-# Fully detach: new session (setsid) AND redirect the whole command's fds to the
-# log / /dev/null. Redirecting only the inner process leaves the wrapper holding
-# DevPod's agent pipe open, which hangs `devpod up` until the server exits.
-setsid bash -c "pnpm -F ${GBL_GAME_PACKAGE} dev" >/tmp/dev.log 2>&1 </dev/null &
-disown 2>/dev/null || true
+devrouter-process ensure \
+  --name game \
+  --match 'pnpm(\.cjs)? .*dev' \
+  --log /tmp/dev.log \
+  -- bash -lc "exec pnpm -F '${GBL_GAME_PACKAGE}' dev"
 
 if [ "${GBL_DEV_MODE:-}" = "starter" ]; then
   printf '[post-start] App      -> %s      (first compile ~30-60s)\n' "$NEXTAUTH_URL"

--- a/.devrouter.yml
+++ b/.devrouter.yml
@@ -8,7 +8,7 @@
 # `for a in app oidc db; do dev app run "$a" --yes; done`. Requires devrouter >= 0.0.23.
 version: 1
 devrouter:
-  version: 0.0.30
+  version: 0.0.31
 project:
   name: demo-game
 apps:

--- a/.devrouter.yml
+++ b/.devrouter.yml
@@ -5,7 +5,7 @@
 #
 # Usage: `dev up` + `dev tls install` (creates devnet + the mkcert CA), THEN
 # bring the devcontainer up (devnet is external — must pre-exist), then
-# `for a in app oidc db; do dev app run "$a" --yes; done`. Requires devrouter >= 0.0.23.
+# `for a in app oidc db; do dev app run "$a" --yes; done`. Requires devrouter >= 0.0.31.
 version: 1
 devrouter:
   version: 0.0.31

--- a/.devrouter.yml
+++ b/.devrouter.yml
@@ -19,14 +19,13 @@ apps:
     runtime: proxy
     upstream: ${WORKSPACE}-app:3000
 
-  # Local OIDC mock — shares the app container's netns, so it is reached on devnet
-  # as `${WORKSPACE}-app:8090`. Browser + app server both use this host as the
-  # NextAuth issuer (https://oidc.demo-game.localhost/default).
+  # Local OIDC mock — owns a workspace-scoped devnet alias so app recreation does
+  # not break the issuer. Browser + app server both use the routed host.
   - name: oidc
     host: oidc.demo-game.localhost
     protocol: http
     runtime: proxy
-    upstream: ${WORKSPACE}-app:8090
+    upstream: ${WORKSPACE}-oidc:8090
 
   # Postgres: db.demo-game.localhost:5432 -> `${WORKSPACE}-db` (SNI). Connect with
   # direct-SSL: psql "host=db.demo-game.localhost port=5432 user=prisma

--- a/.devrouter.yml
+++ b/.devrouter.yml
@@ -8,7 +8,7 @@
 # `for a in app oidc db; do dev app run "$a" --yes; done`. Requires devrouter >= 0.0.23.
 version: 1
 devrouter:
-  version: 0.0.25
+  version: 0.0.30
 project:
   name: demo-game
 apps:

--- a/docs/solutions/integration/devpod-oidc-network-namespace-recreate.md
+++ b/docs/solutions/integration/devpod-oidc-network-namespace-recreate.md
@@ -59,7 +59,7 @@ the managed game process (`.devcontainer/post-start.sh:27`). Starter mode keeps
 its existing shared-namespace topology because the rewrite is explicitly
 guarded from starter execution (`.devcontainer/starter/docker-compose.yml:66`).
 
-The game process itself remains owned by the exact devrouter 0.0.30 helper
+The game process itself remains owned by the exact devrouter 0.0.31 helper
 (`.devcontainer/Dockerfile:21`) and starts through one
 `devrouter-process ensure` call (`.devcontainer/post-start.sh:47`).
 

--- a/docs/solutions/integration/devpod-oidc-network-namespace-recreate.md
+++ b/docs/solutions/integration/devpod-oidc-network-namespace-recreate.md
@@ -1,0 +1,81 @@
+---
+module: devcontainer
+date: 2026-07-14
+problem_type: integration
+severity: medium
+symptoms:
+  - "workspace ensure times out with HTTP route readiness timed out: oidc (502)"
+  - "The OIDC container remains running but localhost:8090 disappears from the recreated app container"
+  - "A repeated ensure recreates the app instead of reusing the healthy workspace"
+root_cause: "The OIDC sidecar shared the app container network namespace, while DevPod recovery recreated only the app container."
+tags: [devrouter, devpod, devcontainer, docker-compose, oidc, worktrees]
+---
+
+# DevPod App Recreation Strands a Shared-Namespace OIDC Sidecar
+
+## Problem
+
+The maintainer devcontainer originally ran the OIDC mock with
+`network_mode: service:app`. Devrouter 0.0.30 can perform one bounded app
+recreation when `workspace ensure` finds stale container or route state
+(`.agents/skills/devrouter/SKILL.md:136`). DevPod
+recreated the selected app service but left the OIDC container running in the
+old app container's network namespace. The game recovered on port 3000, while
+the OIDC route returned 502 because port 8090 no longer existed in the new app
+namespace.
+
+## Symptoms
+
+- `workspace ensure` ended with
+  `HTTP route readiness timed out: oidc (502)` after recreating the app.
+- Container inspection showed the OIDC `NetworkMode` still referenced the
+  replaced app container ID.
+- The new app answered locally on port 3000, but a local discovery request on
+  port 8090 failed.
+- After changing the desired topology, an old workspace reported
+  `Workspace upstream '<workspace>-oidc' must resolve to exactly one running container; found 0`
+  until its OIDC service was reconciled once.
+
+## What Didn't Work
+
+Recreating the stale OIDC container repaired one running workspace, but it did
+not change the topology. The next app-only recovery could strand it again.
+
+A single successful `workspace ensure` was also insufficient proof. The second
+run exercised the bounded recovery path and exposed that the app and OIDC
+lifecycle ownership did not match.
+
+## Solution
+
+Give the maintainer OIDC service its own default/devnet attachments and the
+workspace-owned `${WORKSPACE}-oidc` alias
+(`.devcontainer/docker-compose.yml:90`). Route the OIDC proxy directly to that
+alias (`.devrouter.yml:22`).
+
+Keep browser and server-side issuer identity aligned for linked worktrees by
+mapping the namespaced OIDC host to the host gateway
+(`.devcontainer/docker-compose.yml:50`) and exporting the matching issuer into
+the managed game process (`.devcontainer/post-start.sh:27`). Starter mode keeps
+its existing shared-namespace topology because the rewrite is explicitly
+guarded from starter execution (`.devcontainer/starter/docker-compose.yml:66`).
+
+The game process itself remains owned by the exact devrouter 0.0.30 helper
+(`.devcontainer/Dockerfile:21`) and starts through one
+`devrouter-process ensure` call (`.devcontainer/post-start.sh:47`).
+
+## Why This Works
+
+App recreation no longer changes the network namespace that owns port 8090.
+The OIDC container has a stable, independently verifiable devnet alias, so
+devrouter can prove app, OIDC, and database upstream ownership separately.
+Namespaced issuer URLs still reach Traefik from inside the app container and
+resolve to the same OIDC endpoint used by the browser.
+
+## Prevention
+
+After changing devcontainer lifecycle or network ownership, run
+`devrouter workspace ensure .` twice in a linked worktree. Capture the app and
+sidecar container IDs plus `/tmp/devrouter-process-game.state` before and after
+the second run. Both container IDs and the managed PID/process-group/fingerprint
+must remain unchanged, while the namespaced app route and OIDC discovery endpoint
+must respond successfully.


### PR DESCRIPTION
## Summary

Upgrade the maintainer devcontainer to devrouter 0.0.31 and adopt its managed workspace lifecycle. Linked worktrees now retain durable ownership metadata, recover cleanly, and can be garbage-collected after an out-of-band Git worktree removal.

The branch also separates the OIDC mock from the app container's network namespace. Recreating the app no longer strands OIDC on an obsolete namespace.

## Changes

- Upgrade `.devrouter.yml`, generated agent guidance, and the devcontainer's pinned process helper to 0.0.31.
- Add default and devrouter-specific Compose overlays for workspace identity and Git common-directory access.
- Move OIDC onto its own workspace-scoped `devnet` alias and keep namespaced issuer URLs consistent inside the app.
- Replace the ad-hoc background process guard with `devrouter-process ensure`.
- Document the OIDC recreation failure and the current 0.0.31 prerequisite.

## Verification

- `devrouter repo devcontainer verify --repo . --json`: 5 passed, 0 warnings, 0 errors.
- `devrouter doctor --repo . --json`: 23 passed, 1 unrelated legacy-workspace warning, 0 errors.
- Parsed both default and managed Compose overlay combinations with `docker compose config --quiet`.
- `bash -n` passed for the changed shell flow; ShellCheck passed after excluding two pre-existing source/literal warnings.
- Opengrep ran 90 applicable rules across the changed runtime/configuration files with 0 findings.
- Gemini 3.5 Flash High reviewed the full branch; its CLI-version and documentation findings were resolved.

Live isolated-worktree proof with devrouter 0.0.31:

- Built the devcontainer from the published 0.0.31 package.
- App route returned HTTP 200; OIDC discovery returned the expected namespaced issuer.
- `workspace stop` removed all three routes while retaining the DevPod and ownership record.
- `workspace ensure` restored the same workspace and all routes.
- Dirty full `workspace down` failed before any side effects.
- After an out-of-band `git worktree remove`, GC reported the managed owner as missing, selected only that workspace, and cleaned it with 0 errors.
- Final residue check found no test route, DevPod, container, network, volume, ownership record, worktree path, or branch.

## Before merge

- Let the PR checks complete successfully.
- No additional manual runtime verification is required; the full linked-worktree lifecycle was exercised locally.

## Notes

One older local worktree has no ownership record. GC correctly treats it as legacy and refuses automatic cleanup; this branch does not modify it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workspace-aware development container support for linked worktrees.
  - Added isolated routing for application, OIDC, and database services.
  - Added automatic workspace-specific hostnames and authentication issuer configuration.
  - Added managed game development server startup and recovery.

- **Bug Fixes**
  - Improved OIDC availability when the application container is recreated.
  - Prevented routing and authentication failures caused by stale container networking.

- **Documentation**
  - Updated setup, workspace lifecycle, routing, prerequisites, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->